### PR TITLE
🔀 Merge to Main: 💄 Remove bottom border from MutateSignal header 

### DIFF
--- a/src/pages/incoming-signal/MutateSignal.tsx
+++ b/src/pages/incoming-signal/MutateSignal.tsx
@@ -86,7 +86,7 @@ const MutateSignal: React.FC = () => {
 
     return (
         <div className="flex flex-col gap-2">
-            <div className="flex gap-4 items-center h-10 border-b border-slate-400">
+            <div className="flex gap-4 items-center h-10">
                 <p>Select any widget to modify its Signal value in real-time</p>
                 <p className={selectedId ? 'block' : 'hidden'}>
                     Widget is :


### PR DESCRIPTION
## 📝 Summary  
This update applies a small UI refinement to the MutateSignal component by removing the bottom border from its widget selection header. The change aims to create a cleaner, more streamlined visual appearance for the widget modification interface.  

### ✨ Key Changes  
- Removed `border-b border-slate-400` classes from the header `div` in `MutateSignal.tsx`.  
- Simplified the header design for a less visually segmented look.  