### PR TITLE
🔀 Merge to Main: ♻️ Simplify Redux & Signal headers by disabling counter and removing theme toggle

### DIFF
--- a/src/pages/redux/Redux.tsx
+++ b/src/pages/redux/Redux.tsx
@@ -7,7 +7,7 @@ const Redux: React.FC = () => {
     return (
         <ReduxProvider>
             <div className="w-full h-screen !p-10 flex flex-col gap-8">
-                <Header />
+                <Header disableCounter={true} />
                 <WidgetContainer />
             </div>
         </ReduxProvider>

--- a/src/pages/redux/components/Header.tsx
+++ b/src/pages/redux/components/Header.tsx
@@ -1,9 +1,5 @@
-// import React, { useEffect } from 'react'
 import CounterDisplay from './CounterDisplay'
-import ThemeToggle from './ThemeButton'
-// import { useDispatch } from 'react-redux'
-// import { mouseActions } from '../../../store/redux'
-// import MousePosition from './MousePosition'
+// import ThemeToggle from './ThemeButton'
 import { Link } from 'react-router-dom'
 
 type Props = {
@@ -15,7 +11,7 @@ type Props = {
 const ThemeAndLink = ({ disabled }: { disabled: boolean }) => {
     return (
         <div className="flex items-center gap-2">
-            {!disabled && <ThemeToggle />}
+            {!disabled && <></>}
             <Link to="/" className='bg-slate-700 w-[100px] h-12 flex justify-center items-center rounded'>Home</Link>
         </div>
     );

--- a/src/pages/signal/Signal.tsx
+++ b/src/pages/signal/Signal.tsx
@@ -4,7 +4,7 @@ import WidgetContainer, { WidgetList } from './components/WidgetContainer'
 
 const Signal: React.FC = () => {
     return <div className="w-full h-screen !p-10 flex flex-col gap-8">
-        <Header />
+        <Header disableCounter={true} />
         <WidgetContainer>
             <WidgetList />
         </WidgetContainer>

--- a/src/pages/signal/components/Header.tsx
+++ b/src/pages/signal/components/Header.tsx
@@ -1,8 +1,5 @@
-// import React, { useEffect } from 'react'
 import CounterDisplay from './CounterDisplay';
-import ThemeToggle from './ThemeButton';
-// import { setMousePositionSignal } from '../../../store/signal';
-// import MousePosition from './MousePosition';
+// import ThemeToggle from './ThemeButton';
 import { Link } from 'react-router-dom';
 
 type Props = {
@@ -14,7 +11,7 @@ type Props = {
 const ThemeAndLink = ({ disabled }: { disabled: boolean }) => {
     return (
         <div className="flex items-center gap-2">
-            {!disabled && <ThemeToggle />}
+            {!disabled && <></>}
             <Link to="/" className='bg-slate-700 w-[100px] h-12 flex justify-center items-center rounded'>Home</Link>
         </div>
     );


### PR DESCRIPTION
## 📝 Summary  
This PR streamlines the Header components on both the **Redux** and **Signal** pages by disabling the counter and removing the theme toggle button. These updates ensure a consistent header appearance and simplified behavior across these sections.  

### 🔧 Key Changes  
- **Redux & Signal pages**  
  - Always pass `disableCounter={true}` to the `Header` component for consistent counter behavior.  

- **Header components** (`redux/components/Header.tsx`, `signal/components/Header.tsx`)  
  - Removed the `ThemeToggle` import.  
  - Replaced the conditional theme toggle rendering with an empty fragment, effectively hiding the button permanently.  

### 🎯 Impact  
- Provides a cleaner and more uniform header layout across pages.  
- Removes unused UI elements to reduce visual clutter.  